### PR TITLE
Don't wrap keywords (id, label) with quotation marks, fix #132

### DIFF
--- a/src/main/java/com/microsoft/spring/data/gremlin/common/Constants.java
+++ b/src/main/java/com/microsoft/spring/data/gremlin/common/Constants.java
@@ -48,10 +48,12 @@ public class Constants {
     public static final String GREMLIN_PRIMITIVE_HAS_STRING = "has('%s', '%s')";
     public static final String GREMLIN_PRIMITIVE_HAS_NUMBER = "has('%s', %d)";
     public static final String GREMLIN_PRIMITIVE_HAS_BOOLEAN = "has('%s', %b)";
+    public static final String GREMLIN_PRIMITIVE_HAS_KEYWORD = "has(%s, '%s')";
 
     public static final String GREMLIN_PRIMITIVE_PROPERTY_STRING = "property('%s', '%s')";
     public static final String GREMLIN_PRIMITIVE_PROPERTY_NUMBER = "property('%s', %d)";
     public static final String GREMLIN_PRIMITIVE_PROPERTY_BOOLEAN = "property('%s', %b)";
+    public static final String GREMLIN_PRIMITIVE_PROPERTY_KEYWORD = "property(%s, '%s')";
 
     public static final String GREMLIN_PRIMITIVE_AND = "and()";
     public static final String GREMLIN_PRIMITIVE_OR = "or()";

--- a/src/main/java/com/microsoft/spring/data/gremlin/conversion/script/GremlinScriptLiteralEdge.java
+++ b/src/main/java/com/microsoft/spring/data/gremlin/conversion/script/GremlinScriptLiteralEdge.java
@@ -49,7 +49,7 @@ public class GremlinScriptLiteralEdge extends AbstractGremlinScriptLiteral imple
         scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_VERTEX, vertexIdFrom));
         scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_ADD_EDGE, label));
         scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_TO_VERTEX, vertexIdTo));
-        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_PROPERTY_STRING, Constants.PROPERTY_ID, id));
+        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_PROPERTY_KEYWORD, Constants.PROPERTY_ID, id));
 
         scriptList.addAll(generateProperties(properties));
 
@@ -80,7 +80,7 @@ public class GremlinScriptLiteralEdge extends AbstractGremlinScriptLiteral imple
 
         scriptList.add(Constants.GREMLIN_PRIMITIVE_GRAPH);
         scriptList.add(Constants.GREMLIN_PRIMITIVE_EDGE_ALL);
-        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_HAS_STRING, Constants.PROPERTY_LABEL, label));
+        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_HAS_KEYWORD, Constants.PROPERTY_LABEL, label));
         scriptList.add(Constants.GREMLIN_PRIMITIVE_DROP);
 
         final String query = String.join(Constants.GREMLIN_PRIMITIVE_INVOKE, scriptList);
@@ -139,7 +139,7 @@ public class GremlinScriptLiteralEdge extends AbstractGremlinScriptLiteral imple
 
         scriptList.add(Constants.GREMLIN_PRIMITIVE_GRAPH);
         scriptList.add(Constants.GREMLIN_PRIMITIVE_EDGE_ALL);
-        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_HAS_STRING, Constants.PROPERTY_LABEL, label));
+        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_HAS_KEYWORD, Constants.PROPERTY_LABEL, label));
 
         final String query = String.join(Constants.GREMLIN_PRIMITIVE_INVOKE, scriptList);
 

--- a/src/main/java/com/microsoft/spring/data/gremlin/conversion/script/GremlinScriptLiteralVertex.java
+++ b/src/main/java/com/microsoft/spring/data/gremlin/conversion/script/GremlinScriptLiteralVertex.java
@@ -38,7 +38,7 @@ public class GremlinScriptLiteralVertex extends AbstractGremlinScriptLiteral imp
 
         scriptList.add(Constants.GREMLIN_PRIMITIVE_GRAPH);
         scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_ADD_VERTEX, label));
-        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_PROPERTY_STRING, Constants.PROPERTY_ID, id));
+        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_PROPERTY_KEYWORD, Constants.PROPERTY_ID, id));
 
         scriptList.addAll(generateProperties(properties));
 
@@ -69,7 +69,7 @@ public class GremlinScriptLiteralVertex extends AbstractGremlinScriptLiteral imp
 
         scriptList.add(Constants.GREMLIN_PRIMITIVE_GRAPH);
         scriptList.add(Constants.GREMLIN_PRIMITIVE_VERTEX_ALL);
-        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_HAS_STRING, Constants.PROPERTY_LABEL, label));
+        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_HAS_KEYWORD, Constants.PROPERTY_LABEL, label));
         scriptList.add(Constants.GREMLIN_PRIMITIVE_DROP);
 
         final String query = String.join(Constants.GREMLIN_PRIMITIVE_INVOKE, scriptList);
@@ -128,7 +128,7 @@ public class GremlinScriptLiteralVertex extends AbstractGremlinScriptLiteral imp
 
         scriptList.add(Constants.GREMLIN_PRIMITIVE_GRAPH);
         scriptList.add(Constants.GREMLIN_PRIMITIVE_VERTEX_ALL);
-        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_HAS_STRING, Constants.PROPERTY_LABEL, label));
+        scriptList.add(String.format(Constants.GREMLIN_PRIMITIVE_HAS_KEYWORD, Constants.PROPERTY_LABEL, label));
 
         final String query = String.join(Constants.GREMLIN_PRIMITIVE_INVOKE, scriptList);
 

--- a/src/test/java/com/microsoft/spring/data/gremlin/conversion/script/GremlinScriptLiteralEdgeUnitTest.java
+++ b/src/test/java/com/microsoft/spring/data/gremlin/conversion/script/GremlinScriptLiteralEdgeUnitTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.spring.data.gremlin.conversion.script;
+
+import com.microsoft.spring.data.gremlin.common.domain.Person;
+import com.microsoft.spring.data.gremlin.common.domain.Project;
+import com.microsoft.spring.data.gremlin.common.domain.Relationship;
+import com.microsoft.spring.data.gremlin.conversion.MappingGremlinConverter;
+import com.microsoft.spring.data.gremlin.conversion.source.GremlinSource;
+import com.microsoft.spring.data.gremlin.mapping.GremlinMappingContext;
+import com.microsoft.spring.data.gremlin.repository.support.GremlinEntityInformation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GremlinScriptLiteralEdgeUnitTest {
+
+    private MappingGremlinConverter converter;
+    private GremlinMappingContext mappingContext;
+    private GremlinSource gremlinSource;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Before
+    public void setup() {
+        this.mappingContext = new GremlinMappingContext();
+        this.mappingContext.setApplicationContext(this.applicationContext);
+        this.mappingContext.afterPropertiesSet();
+        this.mappingContext.getPersistentEntity(Person.class);
+        this.converter = new MappingGremlinConverter(this.mappingContext);
+
+        final Relationship relationship = new Relationship("456", "rel-name", null,
+                new Person("123", "bill"), // from
+                new Project("321", "ms-project", null) // to
+        );
+        @SuppressWarnings("unchecked") final GremlinEntityInformation info =
+                new GremlinEntityInformation(Relationship.class);
+        gremlinSource = info.getGremlinSource();
+        this.converter.write(relationship, gremlinSource);
+    }
+
+    @Test
+    public void testGenerateCountScript() {
+        final List<String> queryList = new GremlinScriptLiteralEdge().generateCountScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.E()");
+    }
+
+    @Test
+    public void testGenerateFindByIdScript() {
+        final List<String> queryList = new GremlinScriptLiteralEdge().generateFindByIdScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.E('456')");
+    }
+
+    @Test
+    public void testGenerateFindAllScript() {
+        final List<String> queryList = new GremlinScriptLiteralEdge().generateFindAllScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.E().has(label, 'label-relationship')");
+    }
+
+    @Test
+    public void testGenerateInsertScript() {
+        final List<String> queryList = new GremlinScriptLiteralEdge().generateInsertScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.V('123').addE('label-relationship').to(g.V('321'))" +
+                ".property(id, '456').property('name', 'rel-name').property('location', 'null')");
+    }
+
+    @Test
+    public void testGenerateUpdateScript() {
+        final List<String> queryList = new GremlinScriptLiteralEdge().generateUpdateScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.E('456').property('name', 'rel-name').property('location', 'null')");
+    }
+
+    @Test
+    public void testGenerateDeleteByIdScript() {
+        final List<String> queryList = new GremlinScriptLiteralEdge().generateDeleteByIdScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.E('456').drop()");
+    }
+
+    @Test
+    public void testGenerateDeleteAllScript() {
+        final List<String> queryList = new GremlinScriptLiteralEdge().generateDeleteAllScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.E().drop()");
+    }
+
+    @Test
+    public void testGenerateDeleteAllByClassScript() {
+        final List<String> queryList = new GremlinScriptLiteralEdge().generateDeleteAllByClassScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.E().has(label, 'label-relationship').drop()");
+    }
+}

--- a/src/test/java/com/microsoft/spring/data/gremlin/conversion/script/GremlinScriptLiteralVertexUnitTest.java
+++ b/src/test/java/com/microsoft/spring/data/gremlin/conversion/script/GremlinScriptLiteralVertexUnitTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.spring.data.gremlin.conversion.script;
+
+import com.microsoft.spring.data.gremlin.common.domain.Person;
+import com.microsoft.spring.data.gremlin.conversion.MappingGremlinConverter;
+import com.microsoft.spring.data.gremlin.conversion.source.GremlinSource;
+import com.microsoft.spring.data.gremlin.mapping.GremlinMappingContext;
+import com.microsoft.spring.data.gremlin.repository.support.GremlinEntityInformation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GremlinScriptLiteralVertexUnitTest {
+
+    private MappingGremlinConverter converter;
+    private GremlinMappingContext mappingContext;
+    private GremlinSource gremlinSource;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+
+    @Before
+    public void setup() {
+        this.mappingContext = new GremlinMappingContext();
+        this.mappingContext.setApplicationContext(this.applicationContext);
+        this.mappingContext.afterPropertiesSet();
+        this.mappingContext.getPersistentEntity(Person.class);
+        this.converter = new MappingGremlinConverter(this.mappingContext);
+
+        final Person person = new Person("123", "bill");
+        @SuppressWarnings("unchecked") final GremlinEntityInformation info = new GremlinEntityInformation(Person.class);
+        gremlinSource = info.getGremlinSource();
+        this.converter.write(person, gremlinSource);
+    }
+
+    @Test
+    public void testGenerateCountScript() {
+        final List<String> queryList = new GremlinScriptLiteralVertex().generateCountScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.V()");
+    }
+
+    @Test
+    public void testGenerateFindByIdScript() {
+        final List<String> queryList = new GremlinScriptLiteralVertex().generateFindByIdScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.V('123')");
+    }
+
+    @Test
+    public void testGenerateFindAllScript() {
+        final List<String> queryList = new GremlinScriptLiteralVertex().generateFindAllScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.V().has(label, 'label-person')");
+    }
+
+    @Test
+    public void testGenerateInsertScript() {
+        final List<String> queryList = new GremlinScriptLiteralVertex().generateInsertScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.addV('label-person').property(id, '123').property('name', 'bill')");
+    }
+
+    @Test
+    public void testGenerateUpdateScript() {
+        final List<String> queryList = new GremlinScriptLiteralVertex().generateUpdateScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.V('123').property('name', 'bill')");
+    }
+
+    @Test
+    public void testGenerateDeleteByIdScript() {
+        final List<String> queryList = new GremlinScriptLiteralVertex().generateDeleteByIdScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.V('123').drop()");
+    }
+
+    @Test
+    public void testGenerateDeleteAllScript() {
+        final List<String> queryList = new GremlinScriptLiteralVertex().generateDeleteAllScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.V().drop()");
+    }
+
+    @Test
+    public void testGenerateDeleteAllByClassScript() {
+        final List<String> queryList = new GremlinScriptLiteralVertex().generateDeleteAllByClassScript(gremlinSource);
+        assertEquals(queryList.get(0), "g.V().has(label, 'label-person').drop()");
+    }
+}

--- a/src/test/java/com/microsoft/spring/data/gremlin/conversion/script/GremlinScriptLiteralVertexUnitTest.java
+++ b/src/test/java/com/microsoft/spring/data/gremlin/conversion/script/GremlinScriptLiteralVertexUnitTest.java
@@ -31,7 +31,6 @@ public class GremlinScriptLiteralVertexUnitTest {
     @Mock
     private ApplicationContext applicationContext;
 
-
     @Before
     public void setup() {
         this.mappingContext = new GremlinMappingContext();


### PR DESCRIPTION
## Description
`spring-data-gremlin` surrounds reserved property keywords such as id and label with apostrophes. This results in `id` and `label` to be treated as standard properties.

I have "integration tested" the changes in this PR against `gremlin-server` and `aws neptune`

See #132 for more information/discussion.

## Todos
- [x] Tests
- [ ] Documentation

## Steps to Test
Unit tests:
`com.microsoft.spring.data.gremlin.conversion.script.GremlinScriptLiteralVertexUnitTest`
`com.microsoft.spring.data.gremlin.conversion.script.GremlinScriptLiteralEdgeUnitTest`
