### PR TITLE
Update Jackson to 2.9.8 due to Security Alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <apache.commons.lang3.version>3.7</apache.commons.lang3.version>
         <org.projectlombok.version>1.16.18</org.projectlombok.version>
         <mockito.core.version>2.8.9</mockito.core.version>
-        <fasterxml.jackson.version>2.9.5</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.9.8</fasterxml.jackson.version>
 
         <skip.integration.tests>true</skip.integration.tests>
     </properties>


### PR DESCRIPTION
Related to the following security alert:

https://github.com/Microsoft/spring-data-gremlin/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open