### PR TITLE
[JanusGraph] Fixed - should contain id property

### DIFF
--- a/src/main/java/com/microsoft/spring/data/gremlin/common/Constants.java
+++ b/src/main/java/com/microsoft/spring/data/gremlin/common/Constants.java
@@ -15,6 +15,7 @@ public class Constants {
     public static final String PROPERTY_LABEL = "label";
     public static final String PROPERTY_TYPE = "type";
     public static final String PROPERTY_VALUE = "value";
+    public static final String PROPERTY_VALUE_WITH_AT = "@value";
     public static final String PROPERTY_PROPERTIES = "properties";
     public static final String PROPERTY_INV = "inV";
     public static final String PROPERTY_OUTV = "outV";

--- a/src/main/java/com/microsoft/spring/data/gremlin/conversion/result/GremlinResultVertexReader.java
+++ b/src/main/java/com/microsoft/spring/data/gremlin/conversion/result/GremlinResultVertexReader.java
@@ -14,6 +14,8 @@ import org.apache.tinkerpop.gremlin.driver.Result;
 import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -31,14 +33,22 @@ public class GremlinResultVertexReader extends AbstractGremlinResultReader imple
 
         Assert.isInstanceOf(Map.class, result.getObject(), "should be one instance of Map");
 
-        @SuppressWarnings("unchecked") final Map<String, Object> map = (Map<String, Object>) result.getObject();
+        Map<String, Object> map = (Map<String, Object>) result.getObject();
+
+        while (map.containsKey(PROPERTY_VALUE_WITH_AT) && !(map instanceof LinkedHashMap)) {
+            final Object value = map.get(PROPERTY_VALUE_WITH_AT);
+            if (value instanceof ArrayList && ((ArrayList) value).size() > 0) {
+                map = (Map<String, Object>) ((ArrayList) value).get(0);
+            } else {
+                map = (Map<String, Object>) value;
+            }
+        }
 
         Assert.isTrue(map.containsKey(PROPERTY_ID), "should contain id property");
         Assert.isTrue(map.containsKey(PROPERTY_LABEL), "should contain label property");
-        Assert.isTrue(map.containsKey(PROPERTY_TYPE), "should contain type property");
+//        Assert.isTrue(map.containsKey(PROPERTY_TYPE), "should contain type property");
         Assert.isTrue(map.containsKey(PROPERTY_PROPERTIES), "should contain properties property");
-        Assert.isTrue(map.get(PROPERTY_TYPE).equals(RESULT_TYPE_VERTEX), "must be vertex type");
-
+//        Assert.isTrue(map.get(PROPERTY_TYPE).equals(RESULT_TYPE_VERTEX), "must be vertex type");
         Assert.isInstanceOf(Map.class, map.get(PROPERTY_PROPERTIES), "should be one instance of Map");
     }
 


### PR DESCRIPTION
## Description
This is the fix related to my comment in https://github.com/microsoft/spring-data-gremlin/issues/230#issuecomment-536178388 about the issue I'm facing in my Java application using `spring-data-gremlin` working with `janusgraph` database
```
java.lang.IllegalArgumentException: should contain id property
```

Gremlin-driver: **3.2.4**
spring-data-gremlin: **2.1.7**
Spring Boot: **2.1.8.RELEASE**

### Root cause
- The issue happened after the library finished inserting the new data into JanusGraph database.
- gremlin-driver returns a different data structure, like as below
![image](https://user-images.githubusercontent.com/5414916/65817275-38466f80-e1d3-11e9-92b3-319719713498.png)
That's why `validate()` function raises `IllegalArgumentException` when it identifies there is no `id`, `label`, `type`, etc... contained in the `Result` instance.

I'm going to write some Tests to cover the logics and test it via my application shortly today.

## Related PRs
N/A

## Todos
- [ ] Tests
- [ ] Documentation

## Steps to Test
Steps to test code change
