### PR TITLE
Allow configuration driven `maxContentLength`. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ target/*
 *.iml
 
 **/target
+
+#Eclipse generated files
+.classpath
+.project
+.settings/
+/.apt_generated/
+/.apt_generated_tests/

--- a/src/main/java/com/microsoft/spring/data/gremlin/common/Constants.java
+++ b/src/main/java/com/microsoft/spring/data/gremlin/common/Constants.java
@@ -90,4 +90,7 @@ public class Constants {
     );
 
     public static final String GREMLIN_PROPERTY_CLASSNAME = "_classname";
+    
+    public static final int DEFAULT_MAX_CONTENT_LENGTH = 65536;
+
 }

--- a/src/main/java/com/microsoft/spring/data/gremlin/common/GremlinConfig.java
+++ b/src/main/java/com/microsoft/spring/data/gremlin/common/GremlinConfig.java
@@ -10,7 +10,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.tinkerpop.gremlin.driver.ser.SerTokens;
 import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
 
 @Getter
@@ -31,6 +30,9 @@ public class GremlinConfig {
     private boolean telemetryAllowed;
 
     private String serializer;
+    
+    private int maxContentLength;
+    
 
     public static GremlinConfigBuilder builder(String endpoint, String username, String password) {
         return defaultBuilder()

--- a/src/main/java/com/microsoft/spring/data/gremlin/common/GremlinFactory.java
+++ b/src/main/java/com/microsoft/spring/data/gremlin/common/GremlinFactory.java
@@ -25,6 +25,11 @@ public class GremlinFactory {
         if (port <= 0 || port > 65535) {
             gremlinConfig.setPort(Constants.DEFAULT_ENDPOINT_PORT);
         }
+        
+        final int maxContentLength = gremlinConfig.getMaxContentLength();
+        if (maxContentLength <= 0) {
+            gremlinConfig.setMaxContentLength(Constants.DEFAULT_MAX_CONTENT_LENGTH);
+        }
 
         this.gremlinConfig = gremlinConfig;
     }
@@ -37,6 +42,7 @@ public class GremlinFactory {
                     .serializer(Serializers.valueOf(this.gremlinConfig.getSerializer()).simpleInstance())
                     .credentials(this.gremlinConfig.getUsername(), this.gremlinConfig.getPassword())
                     .enableSsl(this.gremlinConfig.isSslEnabled())
+                    .maxContentLength(this.gremlinConfig.getMaxContentLength())
                     .port(this.gremlinConfig.getPort())
                     .create();
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
This is to avoid `Max frame length of 65536 has been exceeded.` error.

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos
- [ ] Tests
- [ ] Documentation

## Steps to Test
Steps to test code change
